### PR TITLE
Add JavaScript snippets for Qualtrics integration

### DIFF
--- a/qualtrics_snippets/README.md
+++ b/qualtrics_snippets/README.md
@@ -1,0 +1,36 @@
+# Qualtrics JavaScript Snippets
+
+These simple snippets call the public API hosted on Hugging Face Space and save the results to embedded data fields. Replace the placeholder question IDs with the actual IDs from your Qualtrics survey.
+
+## Files
+
+- `fetch_family_soc.js` – given a two‑digit SOC code, fetch the list of matching six‑digit occupations and store it in `familySOCList`.
+- `fetch_automation_pctile.js` – look up the automation percentile for the chosen six‑digit SOC and save it to `automationPctile`.
+- `fetch_state_foreign_pct.js` – get the foreign‑born labor force share for the respondent's state and save it to `stateForeignPct`.
+- `fetch_occ_foreign_pct.js` – fetch the foreign‑born share for the selected occupation and save it to `occForeignPct`.
+
+## Setup in Qualtrics
+
+1. **Create Embedded Data**
+   - In the Survey Flow, add an *Embedded Data* block before the relevant questions.
+   - Define the following fields: `familySOCList`, `automationPctile`, `stateForeignPct`, `occForeignPct`.
+
+2. **Major SOC Question**
+   - Add a text entry or drop‑down question for the respondent to provide their two‑digit SOC code.
+   - Edit the question's JavaScript and paste the contents of `fetch_family_soc.js`.
+   - Replace `QID_MAJOR` in the snippet with this question's ID.
+
+3. **Six‑Digit SOC Question**
+   - Create a question where respondents select the final six‑digit SOC code. Populate the choices using the embedded field `familySOCList` if desired.
+   - After this question, insert the JavaScript from `fetch_automation_pctile.js` **and** `fetch_occ_foreign_pct.js`.
+   - Replace `QID_SOC` in those snippets with the six‑digit SOC question ID.
+
+4. **State Question**
+   - Add a question that records the respondent's state abbreviation.
+   - Paste the snippet from `fetch_state_foreign_pct.js` and replace `QID_STATE` with the state's question ID.
+
+5. **Testing**
+   - Preview the survey and check the embedded data values in the session. They should populate after the corresponding pages load.
+   - Use the console (F12) to look for any error messages if the fields remain empty.
+
+These snippets intentionally omit UI enhancements. They simply fetch data in the background so you can display or process the results later in your survey.

--- a/qualtrics_snippets/fetch_automation_pctile.js
+++ b/qualtrics_snippets/fetch_automation_pctile.js
@@ -1,0 +1,17 @@
+// Fetch automation percentile for selected six‑digit SOC code
+// Replace QID_SOC with the question ID containing the 6‑digit SOC value
+Qualtrics.SurveyEngine.addOnReady(async function() {
+  const soc = '${q://QID_SOC/ChoiceTextEntryValue}';
+  const url = 'https://iurbinah-soc-lookup-space.hf.space/automation_percentile?soc=' + encodeURIComponent(soc);
+  try {
+    const resp = await fetch(url);
+    if (resp.ok) {
+      const data = await resp.json();
+      Qualtrics.SurveyEngine.setEmbeddedData('automationPctile', data.automation_pctile);
+    } else {
+      console.error('automation fetch failed', resp.status);
+    }
+  } catch (err) {
+    console.error('automation fetch error', err);
+  }
+});

--- a/qualtrics_snippets/fetch_family_soc.js
+++ b/qualtrics_snippets/fetch_family_soc.js
@@ -1,0 +1,17 @@
+// Fetch list of six‑digit occupations for a two‑digit SOC code
+// Replace QID_MAJOR with the question ID capturing the major SOC code
+Qualtrics.SurveyEngine.addOnReady(async function() {
+  const major = '${q://QID_MAJOR/ChoiceTextEntryValue}';
+  const url = 'https://iurbinah-soc-lookup-space.hf.space/automation_family?major=' + encodeURIComponent(major);
+  try {
+    const resp = await fetch(url);
+    if (resp.ok) {
+      const list = await resp.json();
+      Qualtrics.SurveyEngine.setEmbeddedData('familySOCList', JSON.stringify(list));
+    } else {
+      console.error('family fetch failed', resp.status);
+    }
+  } catch (err) {
+    console.error('family fetch error', err);
+  }
+});

--- a/qualtrics_snippets/fetch_occ_foreign_pct.js
+++ b/qualtrics_snippets/fetch_occ_foreign_pct.js
@@ -1,0 +1,17 @@
+// Fetch foreign-born labor force share for selected occupation
+// Replace QID_SOC with the question ID containing the 6‑digit SOC value
+Qualtrics.SurveyEngine.addOnReady(async function() {
+  const soc = '${q://QID_SOC/ChoiceTextEntryValue}';
+  const url = 'https://iurbinah-soc-lookup-space.hf.space/occ_foreign_rate?soc=' + encodeURIComponent(soc);
+  try {
+    const resp = await fetch(url);
+    if (resp.ok) {
+      const data = await resp.json();
+      Qualtrics.SurveyEngine.setEmbeddedData('occForeignPct', data.foreign_pct);
+    } else {
+      console.error('occupation foreign fetch failed', resp.status);
+    }
+  } catch (err) {
+    console.error('occupation foreign fetch error', err);
+  }
+});

--- a/qualtrics_snippets/fetch_state_foreign_pct.js
+++ b/qualtrics_snippets/fetch_state_foreign_pct.js
@@ -1,0 +1,17 @@
+// Fetch foreign-born labor force share for respondent's state
+// Replace QID_STATE with the question ID capturing the state abbreviation
+Qualtrics.SurveyEngine.addOnReady(async function() {
+  const state = '${q://QID_STATE/ChoiceTextEntryValue}';
+  const url = 'https://iurbinah-soc-lookup-space.hf.space/foreign_rate?state=' + encodeURIComponent(state);
+  try {
+    const resp = await fetch(url);
+    if (resp.ok) {
+      const data = await resp.json();
+      Qualtrics.SurveyEngine.setEmbeddedData('stateForeignPct', data.foreign_pct);
+    } else {
+      console.error('state foreign fetch failed', resp.status);
+    }
+  } catch (err) {
+    console.error('state foreign fetch error', err);
+  }
+});


### PR DESCRIPTION
## Summary
- add a new `qualtrics_snippets` folder
- provide minimal JavaScript examples for calling the API from Qualtrics
- document how to configure the questions and embedded data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc8e119848332a62aa16b34bd0065