### PR TITLE
Refresh docs for new Qualtrics snippet location

### DIFF
--- a/API_database_laborforce/Documentation.md
+++ b/API_database_laborforce/Documentation.md
@@ -8,14 +8,12 @@ This directory contains the code and dataset for the SOC lookup API used by the 
 - `data.json` – JSON database containing the SOC records that are loaded by `app.py`.
 - `requirements.txt` – Python dependencies for running the API.
 - `Dockerfile` – Container instructions to build a minimal image for the API.
-- `qualtricsEngine_js_snippets` – Example JavaScript snippets for calling the API from Qualtrics.
+- `../qualtrics_snippets` – Example JavaScript snippets for calling the API from Qualtrics.
 - `data_occup_automation_extended.json` – Automation percentile data augmented with two‑digit major codes and synonyms from ONET.
 - `scripts/onet_synonyms_json.py` – Converts the scraped ONET CSV to JSON.
 - `scripts/extend_automation_data.py` – Generates `data_occup_automation_extended.json`.
 - `data_occup_foreign_extended.json` – Foreign-share percentages with ONET synonyms.
 - `scripts/extend_foreign_data.py` – Builds `data_occup_foreign_extended.json`.
-- `data_occup_automation_extended.json` – Automation data with synonyms.
-- `data_occup_foreign_extended.json` – Foreign-share percentages with synonyms.
 - Legacy `data_occup_consolidated.json` and `scripts/consolidate_occup_data.py` are retained in `../deprecated_code` for reference.
 
 ## Running the API locally

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This pipeline allows the survey to display personalized labor force statistics t
 
 ## Repository Contents
 
- - `API_database_laborforce/` – FastAPI application and JSON datasets powering the SOC lookup service.
+- `API_database_laborforce/` – FastAPI application and JSON datasets powering the SOC lookup service.
+- `qualtrics_snippets/` – JavaScript helpers for calling the API from Qualtrics.
 - `ONET-Scrapped-Data/` – Raw occupation descriptions used to generate synonyms.
 - `data_tables/` – Precomputed CSV tables consumed by the API, including national employment totals.
 - `oesem_may24_data/` – Raw BLS employment spreadsheets downloaded May 2024.

--- a/documentation/pm-notes.md
+++ b/documentation/pm-notes.md
@@ -6,7 +6,7 @@ This document summarizes the data-management workflow for the labor-force projec
 
 The survey workflow relies on a custom API that returns labor‑force statistics based on the respondent's selected occupation and state. The key pieces are:
 
-1. **Qualtrics front end** – JavaScript snippets under `API_database_laborforce/qualtricsEngine_js_snippets/` capture the respondent's two‑digit SOC code and fetch the list of matching six‑digit codes. The chosen code is stored in embedded data.
+1. **Qualtrics front end** – JavaScript snippets under `qualtrics_snippets/` capture the respondent's two‑digit SOC code and fetch the list of matching six‑digit codes. The chosen code is stored in embedded data.
 2. **API back end** – `API_database_laborforce/app.py` serves the `/query` and `/foreign_rate` endpoints. It loads `data.json` (occupation records) and `data_state_foreign.json` (state foreign‑born percentages).
 3. **Precomputed tables** – CSV files in `data_tables/` provide occupation totals, state totals, national employment counts, and automation-risk percentiles. They are produced by the scripts in `scripts/` and notebooks in the repository.
 4. **Automation risk & employment** – `scripts/automation_risk_pipeline.py` merges employment totals with the Frey‑Osborne automation-risk scores, resulting in `automation_risk_percentiles.csv`.

--- a/documentation/qualtrics_workflow.md
+++ b/documentation/qualtrics_workflow.md
@@ -2,12 +2,12 @@
 
 This guide outlines the workflow for using the API with Qualtrics. The
 JavaScript snippets referenced below are located in
-`API_database_laborforce/qualtricsEngine_js_snippets/`.
+`qualtrics_snippets/`.
 
 ## 1. Capture the Major SOC Code
 1. Create a text entry question where respondents type or select the
    two‑digit major SOC group.
-2. Add **Snippet 1** (`fetch_family_soc_codes.txt`) to this question.
+2. Add **Snippet 1** (`fetch_family_soc.js`) to this question.
    It grabs the major code via piping (`\${q://QID123/ChoiceTextEntryValue}`)
    and fetches all six‑digit occupations for that group. The returned
    array is stored in the embedded field `familySOCList` for later use.
@@ -16,13 +16,13 @@ JavaScript snippets referenced below are located in
 1. On the next page, create a text entry question to select the final
    six‑digit SOC code.
 2. Use JavaScript to read `familySOCList` and provide an autocomplete
-   or drop‑down list. See `fetch_6_digit_soc_from_API.txt` for a fully
-   worked example of this behaviour.
+  or drop‑down list. See `fetch_family_soc.js` for a fully worked
+  example of this behaviour.
 3. Store the chosen code in an embedded field (e.g. `chosenSOC`).
 
 ## 3. Save Automation Percentile
 1. After the occupation question, insert **Snippet 2**
-   (`fetch_automation_percentile.txt`). Replace `QID456` with the ID of
+  (`fetch_automation_pctile.js`). Replace `QID456` with the ID of
    the six‑digit SOC question.
 2. The script queries `/automation_percentile` and saves the returned
    value to `automationPctile`.
@@ -30,11 +30,11 @@ JavaScript snippets referenced below are located in
 ## 4. Save State Foreign Share
 1. Capture the respondent's state (two‑letter abbreviation) in a
    separate question.
-2. Add **Snippet 3** (`fetch_state_foreign_pct.txt`) to that page. It
+2. Add **Snippet 3** (`fetch_state_foreign_pct.js`) to that page. It
    calls `/foreign_rate` and writes the percentage to `stateForeignPct`.
 
 ## 5. Save Occupation Foreign Share
-1. Insert **Snippet 4** (`fetch_occ_foreign_pct.txt`) after the
+1. Insert **Snippet 4** (`fetch_occ_foreign_pct.js`) after the
    six‑digit SOC has been recorded.
 2. It looks up the occupation in `/occ_foreign_rate` and stores the
    `foreign_pct` in `occForeignPct`.


### PR DESCRIPTION
## Summary
- update documentation to reference `qualtrics_snippets` directory
- adjust snippet filenames in Qualtrics workflow guide
- mention new snippet folder in project README
- remove duplicate bullet in API documentation

## Testing
- `pip install -r API_database_laborforce/requirements.txt`
- `pip install httpx<0.27`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cf1d84b08332a3cffd26301f66db